### PR TITLE
Update the ISO example to reflect the current BIB architecture

### DIFF
--- a/docs/use-cases/bootc-image-builder-iso/README.md
+++ b/docs/use-cases/bootc-image-builder-iso/README.md
@@ -107,11 +107,22 @@ A sample *config.toml* is already present in the use case directory, that we wil
 
 To generate the ISO image we will be using [bootc-image-builder](https://github.com/osbuild/bootc-image-builder) container image that will help us transitioning from our newly generated bootable container image to a ISO file that can be used with KVM or bare metal to install the OS.
 
-The bootc-image-builder container will need **rootful** access to run and a local copy of the image in system storage. You can pull the image using `root` credentials from quay.io, or you can copy the image from user storage to system storage. Since this image was just built, let's save network traffic and do the latter. You will be asked for your `sudo` password to complete the copy.
+The bootc-image-builder container will need **rootful** access to run and a local copy of the image in system storage. You can pull the image using `root` credentials from quay.io to accomplish this.
 
 ```bash
-podman image scp localhost/rhel-bootc-vm:iso root@localhost::
+sudo podman pull quay.io/$QUAY_USER/rhel-bootc-vm:iso
 ```
+
+??? tip "Using podman image scp"
+
+    You can use `podman` to copy images between remote hosts using 
+    SCP with the `image` subcommand. This will also work for local
+    storage on Linux without using SSHd. For example, to copy the 
+    locally built image to system storage without pulling from the quay.io:
+    
+    ```bash
+    podman image scp quay.io/$QUAY_USER/rhel-bootc-vm:iso root@localhost::
+    ```
 
 Let's proceed with the ISO image creation:
 
@@ -125,11 +136,10 @@ sudo podman run \
     -v /var/lib/containers/storage:/var/lib/containers/storage \
     registry.redhat.io/rhel9/bootc-image-builder:latest \
     --type iso \
-    localhost/rhel-bootc-vm:iso
+    quay.io/$QUAY_USER/rhel-bootc-vm:iso
 ```
-!!! tip If you pulled the image from quay.io, use the full path you used to push.
 
-We will use the image we built before to create our image in the **output** folder.
+We will use the image we built to create our ISO in the **output** folder.
 
 The process will take care of all required steps (deploying the image, SELinux configuration, filesystem configuration, ostree configuration, etc.), after a couple of minutes we will find in the output:
 

--- a/docs/use-cases/bootc-image-builder-iso/README.md
+++ b/docs/use-cases/bootc-image-builder-iso/README.md
@@ -78,7 +78,7 @@ export QUAY_USER=YOURQUAYUSERNAME
 ```
 
 ```bash
-podman tag rhel-bootc-vm:httpd quay.io/$QUAY_USER/rhel-bootc-vm:iso
+podman tag rhel-bootc-vm:iso quay.io/$QUAY_USER/rhel-bootc-vm:iso
 ```
 
 Log-in to Quay.io:
@@ -107,9 +107,10 @@ A sample *config.toml* is already present in the use case directory, that we wil
 
 To generate the ISO image we will be using [bootc-image-builder](https://github.com/osbuild/bootc-image-builder) container image that will help us transitioning from our newly generated bootable container image to a ISO file that can be used with KVM or bare metal to install the OS.
 
-The bootc-image-builder container will need **rootful** access to run and a local copy of the image in system storage. You can pull the image using `root` credentials from quay.io to accomplish this.
+The bootc-image-builder container will need **rootful** access to run and a local copy of the image in system storage. You can pull the image using `root` credentials from quay.io to accomplish this. If the repository isn't public, you will need to log into quay.io again. You can control visibility of the repository under `Repository Settings` in the quay.io interface.
 
 ```bash
+sudo podman login -u $QUAY_USER quay.io
 sudo podman pull quay.io/$QUAY_USER/rhel-bootc-vm:iso
 ```
 
@@ -124,7 +125,7 @@ sudo podman pull quay.io/$QUAY_USER/rhel-bootc-vm:iso
     podman image scp quay.io/$QUAY_USER/rhel-bootc-vm:iso root@localhost::
     ```
 
-Let's proceed with the ISO image creation:
+Once the image has been made available, proceed with the ISO image creation:
 
 ```bash
 sudo podman run \

--- a/use-cases/bootc-image-builder-iso/config.toml
+++ b/use-cases/bootc-image-builder-iso/config.toml
@@ -1,7 +1,6 @@
 [customizations.installer.kickstart]
 contents = """
 # Basic setup
-text
 
 network --bootproto=dhcp --device=link --activate 
 

--- a/use-cases/bootc-image-builder-iso/config.toml
+++ b/use-cases/bootc-image-builder-iso/config.toml
@@ -1,4 +1,26 @@
-[[customizations.user]]
-name = "bootc-user"
-password = "redhat"
-groups = ["wheel"]
+[customizations.installer.kickstart]
+contents = """
+# Basic setup
+text
+
+network --bootproto=dhcp --device=link --activate 
+
+# Basic partitioning
+clearpart --all --initlabel --disklabel=gpt
+reqpart --add-boot
+part / --grow --fstype xfs
+
+# No ostreecontainer command needed, instead we lay down the container contents with BIB in the ISO
+
+firewall --disabled
+services --enabled=sshd
+
+# mkpasswd --method=SHA-512 --rounds=4096 redhat
+user --name=bootc-user --groups=wheel --iscrypted --password='$6$rounds=4096$1VjdHWc6vFCglSh9$3HcKRPO8i2ias09AJ9y6FhQu4V/es/evh6/GJtTtduV.K6AExr.eQb/Ava8v0fZhHKTtoFniEGR2nKO.fCear1'
+
+# Only inject a SSH key for root
+rootpw --iscrypted locked
+
+reboot
+"""
+

--- a/use-cases/bootc-image-builder-iso/config.toml
+++ b/use-cases/bootc-image-builder-iso/config.toml
@@ -16,7 +16,7 @@ firewall --disabled
 services --enabled=sshd
 
 # mkpasswd --method=SHA-512 --rounds=4096 redhat
-user --name=bootc-user --groups=wheel --iscrypted --password='$6$rounds=4096$1VjdHWc6vFCglSh9$3HcKRPO8i2ias09AJ9y6FhQu4V/es/evh6/GJtTtduV.K6AExr.eQb/Ava8v0fZhHKTtoFniEGR2nKO.fCear1'
+user --name=bootc-user --groups=wheel --iscrypted --password=$6$rounds=4096$1VjdHWc6vFCglSh9$3HcKRPO8i2ias09AJ9y6FhQu4V/es/evh6/GJtTtduV.K6AExr.eQb/Ava8v0fZhHKTtoFniEGR2nKO.fCear1
 
 # Only inject a SSH key for root
 rootpw --iscrypted locked


### PR DESCRIPTION
Based on updates to how the ISO type works in bootc-image-builder, I reworked part of the example.  ISO is an alias for anaconda-iso, as far as I can tell, so the configs have changed to favor the auto-install via kickstart.

The `config.toml` was changed to a kickstart with the user creation, as just a user config doesn't work any longer.

The docs were updated to reflect that bootc-image-builder only operates on local images by copying the working image to system storage with a mention of pulling the image as root. 

The ISO is also copied to a system location instead of running from the user's home directory, since configuring that directory as a storage pool isn't automatic and outside the scope.

I also updated a few of the commands to try to separate the copy block from the output, but I don't have MKDocs to test the final render.  I had to do some VM / host swapping to get this all to run locally, so it's only mostly tested.