### PR TITLE
Remove dnf update from examples

### DIFF
--- a/use-cases/bootc-container-anaconda-ks/Containerfile.anaconda
+++ b/use-cases/bootc-container-anaconda-ks/Containerfile.anaconda
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-container-httpd/Containerfile.httpd
+++ b/use-cases/bootc-container-httpd/Containerfile.httpd
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-container-replace/Containerfile.replace
+++ b/use-cases/bootc-container-replace/Containerfile.replace
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install nginx && \

--- a/use-cases/bootc-container-simple/Containerfile.simple
+++ b/use-cases/bootc-container-simple/Containerfile.simple
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/bootc-container-update/Containerfile.update
+++ b/use-cases/bootc-container-update/Containerfile.update
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-container-upgrade/Containerfile.upgrade
+++ b/use-cases/bootc-container-upgrade/Containerfile.upgrade
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10-beta/rhel-bootc:10.0-beta
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-image-builder-ami/Containerfile.ami
+++ b/use-cases/bootc-image-builder-ami/Containerfile.ami
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-image-builder-iso/Containerfile.iso
+++ b/use-cases/bootc-image-builder-iso/Containerfile.iso
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \
     systemctl enable httpd && \

--- a/use-cases/bootc-image-builder-qcow/Containerfile.qcow
+++ b/use-cases/bootc-image-builder-qcow/Containerfile.qcow
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:10.0
-RUN dnf -y update && dnf -y install tmux mkpasswd
+RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/image-mode-management-insights/Containerfile.insights
+++ b/use-cases/image-mode-management-insights/Containerfile.insights
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:9.4
-RUN dnf -y update && dnf -y install tmux mkpasswd insights-client
+RUN dnf -y install tmux mkpasswd insights-client
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN echo "This is a RHEL 10 VM installed using a bootable container with Red Hat Insights installed!" > /etc/motd.d/10-first-setup.motd

--- a/use-cases/image-mode-management-insights/Containerfile.insights-update
+++ b/use-cases/image-mode-management-insights/Containerfile.insights-update
@@ -1,6 +1,6 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
 FROM registry.redhat.io/rhel10/rhel-bootc:9.4
-RUN dnf -y update && dnf -y install tmux mkpasswd insights-client
+RUN dnf -y install tmux mkpasswd insights-client
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN echo "This is a RHEL 10 VM installed using a bootable container with Red Hat Insights installed!" > /etc/motd.d/10-first-setup.motd


### PR DESCRIPTION
Doing an dnf update during a build to pull in new packages is an anti-pattern and we should drop it from our Containerfiles.