### PR TITLE
Added soft reboot to update use-case and bump images to RHEL10.1

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,7 +13,7 @@ Creating a container for RHEL Image Mode is as easy as writing and running a Con
 
 
 ```dockerfile
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 ```
 
 You can proceed customizing the image, adding users, packages, configurations, etc following the [Dockerfile Reference](https://docs.docker.com/reference/dockerfile/) as well as providing informative/documentation layers (MAINTAINER, LABEL, etc) following the best-practices of Containerfile creation.

--- a/docs/use-cases/bootc-container-anaconda-ks/README.md
+++ b/docs/use-cases/bootc-container-anaconda-ks/README.md
@@ -3,6 +3,10 @@
 In this example, we will expand the image we built in the [Apache bootc use case](../bootc-container-httpd/README.md) that you can use as a reference for details.
 This way, we will be able to streamline the creation of VMs based on a frozen, immutable configuration that will take few seconds to be deployed.
 
+
+??? tip
+  "We will stay on RHEL9 to further show how to perform major upgrades in a following example."
+
 The Containerfile.anaconda in the example:
 
 - Updates packages
@@ -70,13 +74,13 @@ You can now browse to [https://quay.io/repository/YOURQUAYUSERNAME/rhel-bootc-ht
 ![](./assets/quay-repo-public.png)
 
 
-## Install RHEL 10.0 using the resulting image
+## Install RHEL 9.7 using the resulting image
 
 ### Prepare install media and review the kickstart file
 
-RHEL 10.0 ISO images are available on the [Red Hat Developer portal](https://developers.redhat.com/content-gateway/file/rhel/Red_Hat_Enterprise_Linux_10.0/rhel-10.0-x86_64-boot.iso) and for this use case we will only need the boot image.
+RHEL 9.7 ISO images are available on the [Red Hat Developer portal](https://developers.redhat.com/content-gateway/file/rhel/Red_Hat_Enterprise_Linux_9.7/rhel-9.7-x86_64-boot.iso) and for this use case we will only need the boot image.
 
-Save the image and place it in the use case folder with the name **rhel10.iso**
+Save the image and place it in the use case folder with the name **rhel9.iso**
 
 The kickstart file is a very simple one:
 
@@ -96,16 +100,16 @@ What is relevant is the **ostreecontainer** directive, that references the conta
 
 ### Creating the Virtual Machine in KVM
 
-You are now ready to spin-up a Virtual Machine using the downloaded boot image for RHEL 10.0, injecting and using the kickstart to perform an unattended installation.
+You are now ready to spin-up a Virtual Machine using the downloaded boot image for RHEL 9.7, injecting and using the kickstart to perform an unattended installation.
 
 ```bash
-virt-install --name rhel10-server \
+virt-install --name rhel9-server \
 --memory 4096 \
 --vcpus 2 \
 --disk size=20 \
 --network network=default \
---location ./rhel10.iso \
---os-variant rhel10.0 \
+--location ./rhel9.iso \
+--os-variant rhel9.7 \
 --initrd-inject ks.cfg \
 --extra-args "inst.ks=file:/ks.cfg"
 ```
@@ -117,5 +121,5 @@ In a few seconds, the VM will boot and start the installation, grabbing the cont
 Based on the connection, it can take a while to fetch the container image and complete the setup. Once it is completed, you can log-in with the **bootc-user/redhat** credentials, and you will see the custom Message Of The Day (MOTD) we added in our Containerfile!
 
 ```bash
-This is a RHEL 10.0 VM installed using a bootable container as a source!
+This is a RHEL 9.7 VM installed using a bootable container as a source!
 ```

--- a/docs/use-cases/bootc-container-upgrade/README.md
+++ b/docs/use-cases/bootc-container-upgrade/README.md
@@ -1,6 +1,6 @@
 # Use Case - Upgrading a VM based on a bootc image
 
-In this example, we want to add some bits to the [previously generated httpd image](../bootc-container-anaconda-ks/README.md) to upgrade the system from **RHEL 10.0** to **RHEL 10 Beta**.
+In this example, we want to add some bits to the [previously generated httpd image](../bootc-container-anaconda-ks/README.md) to upgrade the system from **RHEL 9.7** to **RHEL 10.1**.
 
 We will then use **bootc** to manage the system upgrade, and you will see how easy and fast perfoming upgrades is.
 
@@ -94,7 +94,7 @@ The first thing to do is logging in the VM created in the [previous use case](..
 ```bash
  ~ ▓▒░ ssh bootc-user@192.168.124.16
 bootc-user@192.168.124.16's password:
-This is a RHEL 10.0 VM installed using a bootable container as an rpm-ostree source!
+This is a RHEL 9.7 VM installed using a bootable container as an rpm-ostree source!
 Last login: Mon Jul 29 12:03:40 2024 from 192.168.124.1
 [bootc-user@localhost ~]$
 ```
@@ -156,7 +156,7 @@ Let's log back in!
 ```bash
  ~ ▓▒░ ssh bootc-user@192.168.122.19
 bootc-user@192.168.122.19's password:
-This is a RHEL 10.0 VM installed using a bootable container as source!
+This is a RHEL 10.1 VM installed using a bootable container as source!
 This server is now running on RHEL 10 after the latest upgrade.
 Last login: Mon Feb 24 12:15:42 2025 from 192.168.122.1
 [bootc-user@localhost ~]$
@@ -167,12 +167,12 @@ You can already see that something changed, we have a new line in our message of
 ```bash
 [bootc-user@localhost ~]$ cat /etc/os-release
 NAME="Red Hat Enterprise Linux"
-VERSION="10.0 (Coughlan)"
+VERSION="10.1 (Coughlan)"
 ID="rhel"
 ID_LIKE="centos fedora"
-VERSION_ID="10.0"
+VERSION_ID="10.1"
 PLATFORM_ID="platform:el10"
-PRETTY_NAME="Red Hat Enterprise Linux 10.0 Beta (Coughlan)"
+PRETTY_NAME="Red Hat Enterprise Linux 10.1 (Coughlan)"
 ANSI_COLOR="0;31"
 LOGO="fedora-logo-icon"
 CPE_NAME="cpe:/o:redhat:enterprise_linux:10::baseos"
@@ -183,9 +183,9 @@ DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterpr
 BUG_REPORT_URL="https://issues.redhat.com/"
 
 REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 10"
-REDHAT_BUGZILLA_PRODUCT_VERSION=10.0
+REDHAT_BUGZILLA_PRODUCT_VERSION=10.1
 REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
-REDHAT_SUPPORT_PRODUCT_VERSION="10.0 Beta"
+REDHAT_SUPPORT_PRODUCT_VERSION="10.1"
 ```
 
 Here we go, our image is upgraded and fully working. Of course we can use the new image to provision similar VMs that need the same pieces of software on them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,9 +37,9 @@ nav:
   - Use Cases:
     - Build a simple RHEL container: use-cases/bootc-container-simple/README.md
     - Build an Apache RHEL image: use-cases/bootc-container-httpd/README.md
-    - Use a RHEL bootc container to spin up a RHEL 10 VM with Anaconda and Kickstart: use-cases/bootc-container-anaconda-ks/README.md
+    - Use a RHEL bootc container to spin up a RHEL 9 VM with Anaconda and Kickstart: use-cases/bootc-container-anaconda-ks/README.md
     - Update a VM based on a RHEL bootc container as a source adding packages and configuration: use-cases/bootc-container-update/README.md
-    - Upgrade a VM based on RHEL 10.0 bootc container to RHEL 10 Beta: use-cases/bootc-container-upgrade/README.md
+    - Upgrade a VM based on RHEL 9 bootc container to RHEL 10: use-cases/bootc-container-upgrade/README.md
     - Apply a different RHEL container image to an existing VM: use-cases/bootc-container-replace/README.md
     - Generate a RHEL QCOW image for a VM using bootc-image-builder: use-cases/bootc-image-builder-qcow/README.md
     - Generate a RHEL ISO image for a VM using bootc-image-builder: use-cases/bootc-image-builder-iso/README.md

--- a/use-cases/bootc-container-anaconda-ks/Containerfile.anaconda
+++ b/use-cases/bootc-container-anaconda-ks/Containerfile.anaconda
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel9/rhel-bootc:9.7
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
@@ -8,6 +8,6 @@ RUN dnf -y install httpd && \
     mv /var/www /usr/share/www && \
     sed -ie 's,/var/www,/usr/share/www,' /etc/httpd/conf/httpd.conf
 RUN echo "Welcome to the bootc-http instance!" > /usr/share/www/html/index.html
-RUN echo "This is a RHEL 10.0 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
+RUN echo "This is a RHEL 9.7 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
 EXPOSE 80
 CMD [ "/sbin/init" ]

--- a/use-cases/bootc-container-httpd/Containerfile.httpd
+++ b/use-cases/bootc-container-httpd/Containerfile.httpd
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/bootc-container-replace/Containerfile.replace
+++ b/use-cases/bootc-container-replace/Containerfile.replace
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/bootc-container-simple/Containerfile.simple
+++ b/use-cases/bootc-container-simple/Containerfile.simple
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/bootc-container-update/Containerfile.update
+++ b/use-cases/bootc-container-update/Containerfile.update
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel9/rhel-bootc:9.7
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
@@ -8,7 +8,7 @@ RUN dnf -y install httpd && \
     mv /var/www /usr/share/www && \
     sed -ie 's,/var/www,/usr/share/www,' /etc/httpd/conf/httpd.conf
 COPY files/index.html /usr/share/www/html/index.html
-RUN echo "This is a RHEL 10.0 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
+RUN echo "This is a RHEL 9.7 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
 RUN echo "This server now supports MariaDB as a database, after last update" > /etc/motd.d/20-upgrade.motd
 RUN dnf -y install mariadb mariadb-server vim && dnf clean all && rm -rf /var/cache /var/log/dnf && systemctl enable mariadb
 COPY ./files/00-mariadb-tmpfile.conf /usr/lib/tmpfiles.d/

--- a/use-cases/bootc-container-upgrade/Containerfile.upgrade
+++ b/use-cases/bootc-container-upgrade/Containerfile.upgrade
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10-beta/rhel-bootc:10.0-beta
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
@@ -9,6 +9,6 @@ RUN dnf -y install httpd && \
     sed -ie 's,/var/www,/usr/share/www,' /etc/httpd/conf/httpd.conf && \
     mkdir -p /var/log/httpd
 COPY files/index.html /usr/share/www/html/index.html
-RUN echo "This is a RHEL 10.0 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
+RUN echo "This is a RHEL 10.1 VM installed using a bootable container as source!" > /etc/motd.d/10-first-setup.motd
 RUN echo "This server is now running on RHEL 10 after the latest upgrade." > /etc/motd.d/20-upgrade.motd
 EXPOSE 80

--- a/use-cases/bootc-image-builder-ami/Containerfile.ami
+++ b/use-cases/bootc-image-builder-ami/Containerfile.ami
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/bootc-image-builder-iso/Containerfile.iso
+++ b/use-cases/bootc-image-builder-iso/Containerfile.iso
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo
 RUN dnf -y install httpd && \

--- a/use-cases/bootc-image-builder-qcow/Containerfile.qcow
+++ b/use-cases/bootc-image-builder-qcow/Containerfile.qcow
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/image-mode-management-insights/Containerfile.insights
+++ b/use-cases/image-mode-management-insights/Containerfile.insights
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd insights-client
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo

--- a/use-cases/image-mode-management-insights/Containerfile.insights-update
+++ b/use-cases/image-mode-management-insights/Containerfile.insights-update
@@ -1,5 +1,5 @@
 MAINTAINER Alessandro Rossi <al.rossi87@gmail.com>
-FROM registry.redhat.io/rhel10/rhel-bootc:10.0
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 RUN dnf -y install tmux mkpasswd insights-client
 RUN pass=$(mkpasswd --method=SHA-512 --rounds=4096 redhat) && useradd -m -G wheel bootc-user -p $pass
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/wheel-sudo


### PR DESCRIPTION
- Replaced the 'reboot' on the update use case with soft-reboot.
- Bumped the image version to 10.1
- Kept the Anaconda use case to use RHEL9.7 to show the major upgrade further.